### PR TITLE
Add/Fix Aarch64 Support for Periphery

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 komodo_version: "v1.16.12"
 komodo_bin: "periphery-x86_64"
+komodo_bin_aarch64: "periphery-aarch64"
 
 # You should encrypt with `ansible-vault encrypt_string 'supersecretpasskey' --name 'passkey'` 
 # If encrypting, you must run with --ask-vault-pass or have a vault password file.

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -45,6 +45,15 @@
   become: yes
   become_user: "{{ komodo_user }}"
 
+- name: Fail if unsupported architecture
+  fail:
+    msg: "Unsupported architecture: {{ ansible_architecture }}. Supported architectures are x86_64 and aarch64."
+  when: ansible_architecture not in ['x86_64', 'aarch64']
+
+- name: Set Komodo binary based on architecture
+  set_fact:
+    komodo_bin: "{{ komodo_bin if ansible_architecture == 'x86_64' else komodo_bin_aarch64 }}"
+
 - name: Download Komodo Periphery Agent
   get_url:
     url: "https://github.com/mbecker20/komodo/releases/download/{{ komodo_version }}/{{ komodo_bin }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -61,6 +61,7 @@
     mode: "0755"
     owner: "{{ komodo_user }}"
     group: "{{ komodo_group }}"
+    force: yes
 
 - name: Deploy configuration file
   template:

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -52,6 +52,7 @@
     mode: "0755"
     owner: "{{ komodo_user }}"
     group: "{{ komodo_group }}"
+    force: yes
 
 - name: Deploy configuration file
   template:

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -36,6 +36,15 @@
   become: yes
   when: ssl_enabled | default(true)
 
+- name: Fail if unsupported architecture
+  fail:
+    msg: "Unsupported architecture: {{ ansible_architecture }}. Supported architectures are x86_64 and aarch64."
+  when: ansible_architecture not in ['x86_64', 'aarch64']
+
+- name: Set Komodo binary based on architecture
+  set_fact:
+    komodo_bin: "{{ komodo_bin if ansible_architecture == 'x86_64' else komodo_bin_aarch64 }}"
+
 - name: Download Komodo {{ komodo_version }} Periphery Agent
   get_url:
     url: "https://github.com/mbecker20/komodo/releases/download/{{ komodo_version }}/{{ komodo_bin }}"


### PR DESCRIPTION
Currently, the playbook **_only_** attempts to install and use the x64 version of Periphery. This fixes support for aarch64.

Additionally, the `force: yes` flag is set for Periphery downloads to resolve an issue where the x64 binary was not replaced with the aarch64 binary. Without forcing the download to ignore the cache, the playbook would not replace the x64 version with the correct aarch64 build, due to a `"HTTP Error 304: Not Modified"` response. 

_Note: The above issue is probably only relevant if the system already had an incorrect architecture installed before running the playbook._