### PR TITLE
Fix corner cases with binary name based on version number

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,6 @@ playbook and control behavior with variables. Here is an example of doing it wit
     ```sh
     ansible-playbook -i inventory/komodo.yaml playbooks/komodo.yml \
     -e "komodo_version=v1.16.11" \
-    -e "komodo_bin=periphery" \
     --vault-password-file .vault_pass
     ```
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,7 @@
 komodo_version: "v1.16.12"
-komodo_bin: "periphery-x86_64"
-komodo_bin_aarch64: "periphery-aarch64"
+
+# The user can override komodo_bin directly if desired
+komodo_bin: ""
 
 # You should encrypt with `ansible-vault encrypt_string 'supersecretpasskey' --name 'passkey'` 
 # If encrypting, you must run with --ask-vault-pass or have a vault password file.
@@ -31,3 +32,7 @@ logging_level: "info"
 logging_stdio: "standard"
 logging_opentelemetry_service_name: "Komodo-Periphery"
 
+# These variables likely should not ever be changed.
+komodo_bin_x86: "periphery-x86_64"
+komodo_bin_x86_legacy: "periphery"
+komodo_bin_aarch64: "periphery-aarch64"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -50,13 +50,25 @@
     msg: "Unsupported architecture: {{ ansible_architecture }}. Supported architectures are x86_64 and aarch64."
   when: ansible_architecture not in ['x86_64', 'aarch64']
 
-- name: Set Komodo binary based on architecture
+# Choose binary_name based on user override, architecture, and version
+- name: Select Komodo binary
   set_fact:
-    komodo_bin: "{{ komodo_bin if ansible_architecture == 'x86_64' else komodo_bin_aarch64 }}"
+    binary_name: >-
+      {%- if komodo_bin | length > 0 -%}
+        {{ komodo_bin }}
+      {%- elif ansible_architecture == 'aarch64' -%}
+        {{ komodo_bin_aarch64 }}
+      {%- else -%}  {# x86_64 #}
+        {%- if komodo_version|regex_replace('^v','') is version('1.16.12','>=') -%}
+          {{ komodo_bin_x86 }}
+        {%- else -%}
+          {{ komodo_bin_x86_legacy }}
+        {%- endif -%}
+      {%- endif -%}
 
 - name: Download Komodo Periphery Agent
   get_url:
-    url: "https://github.com/moghtech/komodo/releases/download/{{ komodo_version }}/{{ komodo_bin }}"
+    url: "https://github.com/moghtech/komodo/releases/download/{{ komodo_version }}/{{ binary_name }}"
     dest: "{{ komodo_bin_path }}"
     mode: "0755"
     owner: "{{ komodo_user }}"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -66,6 +66,15 @@
         {%- endif -%}
       {%- endif -%}
 
+- name: Debug binary selection
+  debug:
+    msg: >-
+      {%- if komodo_bin | length > 0 -%}
+        Using override binary name: {{ komodo_bin }}
+      {%- else -%}
+        Selecting {{ binary_name }} as target binary for verion: {{ komodo_version }} and arch: {{ ansible_architecture }}
+      {%- endif -%}
+
 - name: Download Komodo Periphery Agent
   get_url:
     url: "https://github.com/moghtech/komodo/releases/download/{{ komodo_version }}/{{ binary_name }}"

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -57,6 +57,15 @@
         {%- endif -%}
       {%- endif -%}
 
+- name: Debug binary selection
+  debug:
+    msg: >-
+      {%- if komodo_bin | length > 0 -%}
+        Using override binary name: {{ komodo_bin }}
+      {%- else -%}
+        Selecting {{ binary_name }} as target binary for verion: {{ komodo_version }} and arch: {{ ansible_architecture }}
+      {%- endif -%}
+
 - name: Download Komodo Periphery Agent
   get_url:
     url: "https://github.com/moghtech/komodo/releases/download/{{ komodo_version }}/{{ binary_name }}"

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -41,13 +41,25 @@
     msg: "Unsupported architecture: {{ ansible_architecture }}. Supported architectures are x86_64 and aarch64."
   when: ansible_architecture not in ['x86_64', 'aarch64']
 
-- name: Set Komodo binary based on architecture
+# Choose binary_name based on user override, architecture, and version
+- name: Select Komodo binary
   set_fact:
-    komodo_bin: "{{ komodo_bin if ansible_architecture == 'x86_64' else komodo_bin_aarch64 }}"
+    binary_name: >-
+      {%- if komodo_bin | length > 0 -%}
+        {{ komodo_bin }}
+      {%- elif ansible_architecture == 'aarch64' -%}
+        {{ komodo_bin_aarch64 }}
+      {%- else -%}  {# x86_64 #}
+        {%- if komodo_version|regex_replace('^v','') is version('1.16.12','>=') -%}
+          {{ komodo_bin_x86 }}
+        {%- else -%}
+          {{ komodo_bin_x86_legacy }}
+        {%- endif -%}
+      {%- endif -%}
 
-- name: Download Komodo {{ komodo_version }} Periphery Agent
+- name: Download Komodo Periphery Agent
   get_url:
-    url: "https://github.com/moghtech/komodo/releases/download/{{ komodo_version }}/{{ komodo_bin }}"
+    url: "https://github.com/moghtech/komodo/releases/download/{{ komodo_version }}/{{ binary_name }}"
     dest: "{{ komodo_bin_path }}"
     mode: "0755"
     owner: "{{ komodo_user }}"


### PR DESCRIPTION
The binary name for x86 changed from `periphery` to `periphery-x86_64` with v1.16.12. This attempts to detect that and automatically select the correct binary, while also allowing for manual override in the event that something changes again in the future.

This also preserves the automatic arch detection functionality introduced in #1 