### PR TITLE
Add support for komodo v1.17.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,10 +44,11 @@ Below are some key variables; see [`defaults/main.yml`](./defaults/main.yml) for
 - **`komodo_allowed_ips`**  
   - You should set this to the host IP of Komodo Core, `127.0.0.1` For example, create a host file with the komodo_allowed_ips set there
 
+- **`komodo_bind_ip`**
+  - New feature to [komodo 1.17.1](https://github.com/moghtech/komodo/releases/tag/v1.17.1) -- this allows IPv6 support in periphery. Playbook will use the default komodo behavior, but it can be overriden to the legacy behaviour by setting `komodo_bind_ip` to `0.0.0.0`
+
 The remaining variables in [`defaults/main.yml`](./defaults/main.yml) are set to sensible values, but you should
 review them and set according to your own needs
-
-You will also need to change the variable for `passkey` to 
 
 ## Installation / Setup
 
@@ -60,6 +61,7 @@ You will also need to change the variable for `passkey` to
                 ansible_host: 192.168.10.20
                 komodo_allowed_ips:
                     - "127.0.0.1"
+                komodo_bind_ip: 0.0.0.0
             komodo_periphery2:
                 ansible_host: 192.168.10.21
                 komodo_allowed_ips:
@@ -120,12 +122,6 @@ playbook and control behavior with variables. Here is an example of doing it wit
    
 6. Run the playbook
 
-    > **Note for Ubuntu remote hosts**
-    Before running the playbook, it seems that the acl package may be missing on Ubuntu which is necessary for Ansible
-    when creating users. So if you are using the `install` function and creating a new system user, 
-    you need to run `sudo apt install acl` *on the remote host*. In a future release I will look into making sure this is checked and
-    installed automatically. In general, if you get a cryptic message about failure to set temporary files, try installing `acl` package.
-   
     Install using default values
 
     ```sh

--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ the numerous edge cases which appear when running it as a docker container.
 
 Below are some key variables; see [`defaults/main.yml`](./defaults/main.yml) for more details:
 
+> **Note for Komodo version v1.17.1+ **
+[komodo 1.17.1](https://github.com/moghtech/komodo/releases/tag/v1.17.1) introduced a possible breaking change
+in order to support IPv6. I am going to continue to honor the upstream default settings, so pay attention
+to the breaking changes in this release. I have introduced a new variable to support this, `komodo_bind_ip`
+which you can set to `0.0.0.0` to return to the previous behavior. This can be easily set in the inventory
+files as shown in the below examples
+
 - **`komodo_action`**  
   - Controls which operation is performed:
     - `"install"`: Installs the agent fresh
@@ -32,10 +39,6 @@ Below are some key variables; see [`defaults/main.yml`](./defaults/main.yml) for
 
 - **`komodo_version`**  
   - The version of Komodo Periphery to install or update.
-
-- **`komodo_delete_user`**  
-  - If `true` during `uninstall`, removes the `komodo_user` entirely.
-  - Default: `false`
   
 - **`passkey`**  
   - This must match the passkey set for your Komodo Core install
@@ -45,7 +48,7 @@ Below are some key variables; see [`defaults/main.yml`](./defaults/main.yml) for
   - You should set this to the host IP of Komodo Core, `127.0.0.1` For example, create a host file with the komodo_allowed_ips set there
 
 - **`komodo_bind_ip`**
-  - New feature to [komodo 1.17.1](https://github.com/moghtech/komodo/releases/tag/v1.17.1) -- this allows IPv6 support in periphery. Playbook will use the default komodo behavior, but it can be overriden to the legacy behaviour by setting `komodo_bind_ip` to `0.0.0.0`
+  - New feature to [komodo 1.17.1](https://github.com/moghtech/komodo/releases/tag/v1.17.1) -- this allows IPv6 support in periphery. Playbook will use the default komodo behavior, but it can be overriden to the legacy behavior by setting `komodo_bind_ip` to `0.0.0.0`
 
 The remaining variables in [`defaults/main.yml`](./defaults/main.yml) are set to sensible values, but you should
 review them and set according to your own needs
@@ -66,6 +69,7 @@ review them and set according to your own needs
                 ansible_host: 192.168.10.21
                 komodo_allowed_ips:
                     - "192.168.10.20"
+                komodo_bind_ip: 0.0.0.0
     ```
 3. **Optional** but recommended. Set an encrypted passkey using `ansible-vault` which matches the passkey set in Komodo Core.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -6,6 +6,13 @@ komodo_bin: ""
 # You should encrypt with `ansible-vault encrypt_string 'supersecretpasskey' --name 'passkey'` 
 # If encrypting, you must run with --ask-vault-pass or have a vault password file.
 passkey: 
+
+# New to v1.17.1 which introduces IPv6 support.
+# If you have issues, set `komodo_bind_ip` to `0.0.0.0`
+# to revert to previous behaviour.
+komodo_bind_ip: "[::]"
+
+# Replace with your komodo core IP if desired so that only core can access it
 komodo_allowed_ips: []
 
 komodo_user: "komodo"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,3 +1,5 @@
+---
+
 - name: Ensure {{ komodo_user }} user exists
   user:
     name: "{{ komodo_user }}"
@@ -49,31 +51,6 @@
   fail:
     msg: "Unsupported architecture: {{ ansible_architecture }}. Supported architectures are x86_64 and aarch64."
   when: ansible_architecture not in ['x86_64', 'aarch64']
-
-# Choose binary_name based on user override, architecture, and version
-- name: Select Komodo binary
-  set_fact:
-    binary_name: >-
-      {%- if komodo_bin | length > 0 -%}
-        {{ komodo_bin }}
-      {%- elif ansible_architecture == 'aarch64' -%}
-        {{ komodo_bin_aarch64 }}
-      {%- else -%}  {# x86_64 #}
-        {%- if komodo_version|regex_replace('^v','') is version('1.16.12','>=') -%}
-          {{ komodo_bin_x86 }}
-        {%- else -%}
-          {{ komodo_bin_x86_legacy }}
-        {%- endif -%}
-      {%- endif -%}
-
-- name: Debug binary selection
-  debug:
-    msg: >-
-      {%- if komodo_bin | length > 0 -%}
-        Using override binary name: {{ komodo_bin }}
-      {%- else -%}
-        Selecting {{ binary_name }} as target binary for verion: {{ komodo_version }} and arch: {{ ansible_architecture }}
-      {%- endif -%}
 
 - name: Download Komodo Periphery Agent
   get_url:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,5 +1,12 @@
 ---
 
+- name: Ensure ACL package exists when creating a new user
+  apt:
+    name: acl
+    state: present
+  become: yes
+  when: komodo_user_exists is not defined or not komodo_user_exists
+
 - name: Ensure {{ komodo_user }} user exists
   user:
     name: "{{ komodo_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,15 +25,7 @@
           {{ komodo_bin_x86_legacy }}
         {%- endif -%}
       {%- endif -%}
-
-- name: Debug binary selection
-  debug:
-    msg: >-
-      {%- if komodo_bin | length > 0 -%}
-        Using override binary name: {{ komodo_bin }}
-      {%- else -%}
-        Selecting {{ binary_name }} as target binary for version: {{ komodo_version }} and arch: {{ ansible_architecture }}
-      {%- endif -%}
+  when: komodo_action == "install" or komodo_action == "update"
 
 - name: Include install tasks
   import_tasks: install.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,5 @@
 ---
+
 - name: Check if {{ komodo_user }} user exists
   command: id -u {{ komodo_user }}
   register: komodo_user_check
@@ -8,6 +9,31 @@
 - name: Set komodo_user_exists fact
   set_fact:
     komodo_user_exists: "{{ komodo_user_check.rc == 0 }}"
+
+# Choose binary_name based on user override, architecture, and version
+- name: Select Komodo binary
+  set_fact:
+    binary_name: >-
+      {%- if komodo_bin | length > 0 -%}
+        {{ komodo_bin }}
+      {%- elif ansible_architecture == 'aarch64' -%}
+        {{ komodo_bin_aarch64 }}
+      {%- else -%} {# x86_64 #}
+        {%- if (komodo_version | regex_replace('^v', '')) is version('1.16.12', '>=') -%}
+          {{ komodo_bin_x86 }}
+        {%- else -%}
+          {{ komodo_bin_x86_legacy }}
+        {%- endif -%}
+      {%- endif -%}
+
+- name: Debug binary selection
+  debug:
+    msg: >-
+      {%- if komodo_bin | length > 0 -%}
+        Using override binary name: {{ komodo_bin }}
+      {%- else -%}
+        Selecting {{ binary_name }} as target binary for version: {{ komodo_version }} and arch: {{ ansible_architecture }}
+      {%- endif -%}
 
 - name: Include install tasks
   import_tasks: install.yml

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -1,4 +1,4 @@
-
+---
 
 - name: Stop periphery service
   shell: |
@@ -40,31 +40,6 @@
   fail:
     msg: "Unsupported architecture: {{ ansible_architecture }}. Supported architectures are x86_64 and aarch64."
   when: ansible_architecture not in ['x86_64', 'aarch64']
-
-# Choose binary_name based on user override, architecture, and version
-- name: Select Komodo binary
-  set_fact:
-    binary_name: >-
-      {%- if komodo_bin | length > 0 -%}
-        {{ komodo_bin }}
-      {%- elif ansible_architecture == 'aarch64' -%}
-        {{ komodo_bin_aarch64 }}
-      {%- else -%}  {# x86_64 #}
-        {%- if komodo_version|regex_replace('^v','') is version('1.16.12','>=') -%}
-          {{ komodo_bin_x86 }}
-        {%- else -%}
-          {{ komodo_bin_x86_legacy }}
-        {%- endif -%}
-      {%- endif -%}
-
-- name: Debug binary selection
-  debug:
-    msg: >-
-      {%- if komodo_bin | length > 0 -%}
-        Using override binary name: {{ komodo_bin }}
-      {%- else -%}
-        Selecting {{ binary_name }} as target binary for verion: {{ komodo_version }} and arch: {{ ansible_architecture }}
-      {%- endif -%}
 
 - name: Download Komodo Periphery Agent
   get_url:

--- a/templates/periphery.config.toml.j2
+++ b/templates/periphery.config.toml.j2
@@ -6,7 +6,12 @@
 port = {{periphery_port}}
 repo_dir = "{{ repo_dir }}"
 stack_dir = "{{ stack_dir }}"
-stats_polling_rate = "{{ stacks_polling_rate }}"  
+stats_polling_rate = "{{ stacks_polling_rate }}"
+
+{#-- Only add bind_ip for Komodo >= v1.17.1 --#}
+{% if (komodo_version | regex_replace('^v', '')) is version('1.17.1', '>=') %}
+bind_ip = "{{ komodo_bind_ip }}"
+{% endif %}
 
 # Docker CLI options
 legacy_compose_cli = false

--- a/templates/periphery.config.toml.j2
+++ b/templates/periphery.config.toml.j2
@@ -10,6 +10,7 @@ stats_polling_rate = "{{ stacks_polling_rate }}"
 
 {#-- Only add bind_ip for Komodo >= v1.17.1 --#}
 {% if (komodo_version | regex_replace('^v', '')) is version('1.17.1', '>=') %}
+{{''}}
 bind_ip = "{{ komodo_bind_ip }}"
 {% endif %}
 


### PR DESCRIPTION
Komodo introduced a new `bind_ip` variable for IPv6 which I wanted to support. Also introduces some additional small fixes.