### PR TITLE
Fix linter warnings on ansible galaxy publish

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,5 +1,5 @@
 ---
-  
+
 name: Publish to Ansible Galaxy
 
 on:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,3 +1,5 @@
+---
+  
 name: Publish to Ansible Galaxy
 
 on:

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -3,9 +3,9 @@ komodo_version: "v1.17.1"
 # The user can override komodo_bin directly if desired
 komodo_bin: ""
 
-# You should encrypt with `ansible-vault encrypt_string 'supersecretpasskey' --name 'passkey'` 
+# You should encrypt with `ansible-vault encrypt_string 'supersecretpasskey' --name 'passkey'`
 # If encrypting, you must run with --ask-vault-pass or have a vault password file.
-passkey: 
+passkey:
 
 # New to v1.17.1 which introduces IPv6 support.
 # If you have issues, set `komodo_bind_ip` to `0.0.0.0`

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,7 +6,7 @@ galaxy_info:
   author: bpbradley
   description: Komodo management in systemd
   license: "license (GPLv3)"
-  min_ansible_version: 2.10
+  min_ansible_version: "2.10"
   platforms:
     - name: Debian
       versions:

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,22 +1,22 @@
 ---
 
 - name: Ensure ACL package exists when creating a new user
-  apt:
+  ansible.builtin.apt:
     name: acl
     state: present
-  become: yes
+  become: true
   when: komodo_user_exists is not defined or not komodo_user_exists
 
-- name: Ensure {{ komodo_user }} user exists
-  user:
+- name: Ensure Komodo user exists
+  ansible.builtin.user:
     name: "{{ komodo_user }}"
     shell: /usr/sbin/nologin
-    create_home: yes
+    create_home: true
     home: "{{ komodo_home }}"
   when: komodo_user_exists is not defined or not komodo_user_exists
 
 - name: Ensure necessary directories
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     owner: "{{ komodo_user }}"
@@ -28,48 +28,49 @@
     - "{{ komodo_service_dir }}"
 
 - name: Ensure SSL directory exists
-  file:
+  ansible.builtin.file:
     path: "/etc/komodo/ssl"
     state: directory
     owner: "{{ komodo_user }}"
     group: "{{ komodo_group }}"
     mode: "0750"
-  become: yes
+  become: true
   when: ssl_enabled | default(true)
 
-- name: Add {{ komodo_user }} user to the docker group
-  user:
+- name: Add Komodo user to the docker group
+  ansible.builtin.user:
     name: "{{ komodo_user }}"
     groups: docker
-    append: yes
+    append: true
 
-- name: Enable lingering for {{ komodo_user }} user
-  command: loginctl enable-linger {{ komodo_user }}
+- name: Enable lingering for Komodo user
+  ansible.builtin.command: loginctl enable-linger {{ komodo_user }}
   changed_when: false
 
 - name: Stop periphery service
-  shell: |
+  ansible.builtin.shell: |
     export XDG_RUNTIME_DIR="/run/user/$(id -u {{ komodo_user }})"
     systemctl --user stop periphery || true
-  become: yes
+  become: true
   become_user: "{{ komodo_user }}"
+  changed_when: false
 
 - name: Fail if unsupported architecture
-  fail:
+  ansible.builtin.fail:
     msg: "Unsupported architecture: {{ ansible_architecture }}. Supported architectures are x86_64 and aarch64."
   when: ansible_architecture not in ['x86_64', 'aarch64']
 
 - name: Download Komodo Periphery Agent
-  get_url:
+  ansible.builtin.get_url:
     url: "https://github.com/moghtech/komodo/releases/download/{{ komodo_version }}/{{ binary_name }}"
     dest: "{{ komodo_bin_path }}"
     mode: "0755"
     owner: "{{ komodo_user }}"
     group: "{{ komodo_group }}"
-    force: yes
+    force: true
 
 - name: Deploy configuration file
-  template:
+  ansible.builtin.template:
     src: periphery.config.toml.j2
     dest: "{{ komodo_config_path }}"
     mode: "0640"
@@ -77,24 +78,25 @@
     group: "{{ komodo_group }}"
 
 - name: Deploy systemd user service file
-  template:
+  ansible.builtin.template:
     src: periphery.service.j2
     dest: "{{ komodo_service_path }}"
     mode: "0644"
     owner: "{{ komodo_user }}"
     group: "{{ komodo_group }}"
 
-- name: Reload systemd for {{ komodo_user }} user
-  shell: |
+- name: Reload systemd for Komodo user
+  ansible.builtin.shell: |
     export XDG_RUNTIME_DIR="/run/user/$(id -u {{ komodo_user }})"
     systemctl --user daemon-reload
-  become: yes
+  become: true
   become_user: "{{ komodo_user }}"
+  changed_when: false
 
 - name: Enable and start periphery service
-  shell: |
+  ansible.builtin.shell: |
     export XDG_RUNTIME_DIR="/run/user/$(id -u {{ komodo_user }})"
     systemctl --user enable --now periphery
-  become: yes
+  become: true
   become_user: "{{ komodo_user }}"
-
+  changed_when: false

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,17 +14,15 @@
 - name: Select Komodo binary
   ansible.builtin.set_fact:
     binary_name: >-
-      { %- if komodo_bin | length > 0 -% }
+      {%- if komodo_bin | length > 0 -%}
         {{ komodo_bin }}
-      { %- elif ansible_architecture == 'aarch64' -% }
+      {%- elif ansible_architecture == 'aarch64' -%}
         {{ komodo_bin_aarch64 }}
-      { %- else -% } { # x86_64 # }
-        { %- if (komodo_version | regex_replace('^v', '')) is version('1.16.12', '>=') -% }
+      {%- else -%} {# x86_64 #}{%- if (komodo_version | regex_replace('^v', '')) is version('1.16.12', '>=') -%}
           {{ komodo_bin_x86 }}
-        { %- else -% }
+      {%- else -%}
           {{ komodo_bin_x86_legacy }}
-        { %- endif -% }
-      { %- endif -% }
+      {%- endif -%} {%- endif -%}
   when: komodo_action == "install" or komodo_action == "update"
 
 - name: Include install tasks

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,40 +1,40 @@
 ---
 
-- name: Check if {{ komodo_user }} user exists
-  command: id -u {{ komodo_user }}
+- name: Check if Komodo user exists
+  ansible.builtin.command: id -u {{ komodo_user }}
   register: komodo_user_check
-  failed_when: false   
-  changed_when: false  
+  failed_when: false
+  changed_when: false
 
 - name: Set komodo_user_exists fact
-  set_fact:
+  ansible.builtin.set_fact:
     komodo_user_exists: "{{ komodo_user_check.rc == 0 }}"
 
 # Choose binary_name based on user override, architecture, and version
 - name: Select Komodo binary
-  set_fact:
+  ansible.builtin.set_fact:
     binary_name: >-
-      {%- if komodo_bin | length > 0 -%}
+      { %- if komodo_bin | length > 0 -% }
         {{ komodo_bin }}
-      {%- elif ansible_architecture == 'aarch64' -%}
+      { %- elif ansible_architecture == 'aarch64' -% }
         {{ komodo_bin_aarch64 }}
-      {%- else -%} {# x86_64 #}
-        {%- if (komodo_version | regex_replace('^v', '')) is version('1.16.12', '>=') -%}
+      { %- else -% } { # x86_64 # }
+        { %- if (komodo_version | regex_replace('^v', '')) is version('1.16.12', '>=') -% }
           {{ komodo_bin_x86 }}
-        {%- else -%}
+        { %- else -% }
           {{ komodo_bin_x86_legacy }}
-        {%- endif -%}
-      {%- endif -%}
+        { %- endif -% }
+      { %- endif -% }
   when: komodo_action == "install" or komodo_action == "update"
 
 - name: Include install tasks
-  import_tasks: install.yml
+  ansible.builtin.import_tasks: install.yml
   when: komodo_action == "install"
 
 - name: Include update tasks
-  import_tasks: update.yml
+  ansible.builtin.import_tasks: update.yml
   when: komodo_action == "update"
 
 - name: Include uninstall tasks
-  import_tasks: uninstall.yml
+  ansible.builtin.import_tasks: uninstall.yml
   when: komodo_action == "uninstall"

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,19 +1,20 @@
 ---
 
 - name: Stop periphery service
-  shell: |
+  ansible.builtin.shell: |
     export XDG_RUNTIME_DIR="/run/user/$(id -u {{ komodo_user }})"
     systemctl --user stop periphery || true
-  become: yes
+  become: true
   become_user: "{{ komodo_user }}"
+  changed_when: false
 
 - name: Disable lingering for komodo user
-  command: loginctl disable-linger {{ komodo_user }}
+  ansible.builtin.command: loginctl disable-linger {{ komodo_user }}
   changed_when: false
   when: komodo_delete_user | default(false)
 
 - name: Remove komodo directories
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: absent
   with_items:
@@ -21,25 +22,26 @@
     - "{{ komodo_config_dir }}"
     - "{{ komodo_service_dir }}"
     - "/etc/komodo/ssl"
-  become: yes
+  become: true
 
 - name: Disable and remove periphery service
-  shell: |
+  ansible.builtin.shell: |
     export XDG_RUNTIME_DIR="/run/user/$(id -u {{ komodo_user }})"
     systemctl --user disable periphery || true
     rm -f {{ komodo_service_path }}
-  become: yes
+  become: true
   become_user: "{{ komodo_user }}"
+  changed_when: false
 
 - name: Remove komodo user
-  user:
+  ansible.builtin.user:
     name: "{{ komodo_user }}"
     state: absent
-    remove: yes
-    force: yes
-  become: yes
+    remove: true
+    force: true
+  become: true
   when: komodo_delete_user | default(false)
 
 - name: Debug message after uninstall
-  debug:
+  ansible.builtin.debug:
     msg: "Uninstallation of {{ komodo_user }} completed successfully! (User removed: {{ komodo_delete_user | default(false) }})"

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -1,21 +1,22 @@
 ---
 
 - name: Stop periphery service
-  shell: |
+  ansible.builtin.shell: |
     export XDG_RUNTIME_DIR="/run/user/$(id -u {{ komodo_user }})"
     systemctl --user stop periphery || true
-  become: yes
+  become: true
   become_user: "{{ komodo_user }}"
+  changed_when: false
 
 - name: Remove old Komodo Periphery binary
-  file:
+  ansible.builtin.file:
     path: "{{ komodo_bin_path }}"
     state: absent
-  become: yes
+  become: true
   when: komodo_bin_path is defined
 
 - name: Ensure necessary directories
-  file:
+  ansible.builtin.file:
     path: "{{ item }}"
     state: directory
     owner: "{{ komodo_user }}"
@@ -27,31 +28,31 @@
     - "{{ komodo_service_dir }}"
 
 - name: Ensure SSL directory exists
-  file:
+  ansible.builtin.file:
     path: "/etc/komodo/ssl"
     state: directory
     owner: "{{ komodo_user }}"
     group: "{{ komodo_group }}"
     mode: "0750"
-  become: yes
+  become: true
   when: ssl_enabled | default(true)
 
 - name: Fail if unsupported architecture
-  fail:
+  ansible.builtin.fail:
     msg: "Unsupported architecture: {{ ansible_architecture }}. Supported architectures are x86_64 and aarch64."
   when: ansible_architecture not in ['x86_64', 'aarch64']
 
 - name: Download Komodo Periphery Agent
-  get_url:
+  ansible.builtin.get_url:
     url: "https://github.com/moghtech/komodo/releases/download/{{ komodo_version }}/{{ binary_name }}"
     dest: "{{ komodo_bin_path }}"
     mode: "0755"
     owner: "{{ komodo_user }}"
     group: "{{ komodo_group }}"
-    force: yes
+    force: true
 
 - name: Deploy configuration file
-  template:
+  ansible.builtin.template:
     src: periphery.config.toml.j2
     dest: "{{ komodo_config_path }}"
     mode: "0640"
@@ -59,23 +60,25 @@
     group: "{{ komodo_group }}"
 
 - name: Deploy systemd user service file
-  template:
+  ansible.builtin.template:
     src: periphery.service.j2
     dest: "{{ komodo_service_path }}"
     mode: "0644"
     owner: "{{ komodo_user }}"
     group: "{{ komodo_group }}"
 
-- name: Reload systemd for {{ komodo_user }} user
-  shell: |
+- name: Reload systemd for Komodo user
+  ansible.builtin.shell: |
     export XDG_RUNTIME_DIR="/run/user/$(id -u {{ komodo_user }})"
     systemctl --user daemon-reload
-  become: yes
+  become: true
   become_user: "{{ komodo_user }}"
+  changed_when: false
 
 - name: Restart periphery service after update
-  shell: |
+  ansible.builtin.shell: |
     export XDG_RUNTIME_DIR="/run/user/$(id -u {{ komodo_user }})"
     systemctl --user restart periphery
-  become: yes
+  become: true
   become_user: "{{ komodo_user }}"
+  changed_when: false


### PR DESCRIPTION
Most issues were regarding using truth values instead of strict booleans, or not specifying the fully qualified module names.