### PR TITLE
Export passkey only when it is defined

### DIFF
--- a/templates/periphery.config.toml.j2
+++ b/templates/periphery.config.toml.j2
@@ -24,7 +24,10 @@ legacy_compose_cli = false
 ssl_enabled = true
 
 allowed_ips = {{komodo_allowed_ips}}
+
+{% if passkey %}
 passkeys = ["{{ passkey }}"]
+{% endif %}
 
 ###########
 # Logging #


### PR DESCRIPTION
This PR makes the Periphery template safer by emitting the `passkeys` field **only** when the user has actually defined a `passkey` variable.

Without this check the template rendered an empty attribute `passkey = [""] `, which:

-  produced an invalid Komodo Periphery configuration (empty array is rejected), and
-  leaked implementation detail that a passkey even exists when none is intended.