### PR TITLE
Allow template files to be overridden

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,10 +22,15 @@ komodo_home: "/home/{{ komodo_user }}"
 komodo_bin_dir: "{{ komodo_home }}/.local/bin"
 komodo_bin_path: "{{ komodo_bin_dir }}/periphery"
 
+
 komodo_config_dir: "{{ komodo_home }}/.config/komodo"
+# default config template
+komodo_config_file_template: "periphery.config.toml.j2"
 komodo_config_path: "{{ komodo_config_dir }}/periphery.config.toml"
 
 komodo_service_dir: "{{ komodo_home }}/.config/systemd/user"
+# default service template
+komodo_service_file_template: "periphery.service.j2"
 komodo_service_path: "{{ komodo_service_dir }}/periphery.service"
 
 periphery_port: 8120
@@ -43,3 +48,5 @@ logging_opentelemetry_service_name: "Komodo-Periphery"
 komodo_bin_x86: "periphery-x86_64"
 komodo_bin_x86_legacy: "periphery"
 komodo_bin_aarch64: "periphery-aarch64"
+
+

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -71,7 +71,7 @@
 
 - name: Deploy configuration file
   ansible.builtin.template:
-    src: periphery.config.toml.j2
+    src: "{{ komodo_config_file_template }}"
     dest: "{{ komodo_config_path }}"
     mode: "0640"
     owner: "{{ komodo_user }}"
@@ -79,7 +79,7 @@
 
 - name: Deploy systemd user service file
   ansible.builtin.template:
-    src: periphery.service.j2
+    src: "{{ komodo_service_file_template }}"
     dest: "{{ komodo_service_path }}"
     mode: "0644"
     owner: "{{ komodo_user }}"

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -53,7 +53,7 @@
 
 - name: Deploy configuration file
   ansible.builtin.template:
-    src: periphery.config.toml.j2
+    src: "{{ komodo_config_file_template }}"
     dest: "{{ komodo_config_path }}"
     mode: "0640"
     owner: "{{ komodo_user }}"
@@ -61,7 +61,7 @@
 
 - name: Deploy systemd user service file
   ansible.builtin.template:
-    src: periphery.service.j2
+    src: "{{ komodo_service_file_template }}"
     dest: "{{ komodo_service_path }}"
     mode: "0644"
     owner: "{{ komodo_user }}"


### PR DESCRIPTION
This pull request adds the ability to override the systemd service file and komodo configuration. This follows Ansible best-practices, as opposed to overloading with vars the template files.

### Configuration Management Enhancements:

* [`defaults/main.yml`](diffhunk://#diff-23e21b6c89468f7534697ad091835b3ee5e0213b37ace489488234e5a9548ec4R25-R33): Added new variables `komodo_config_file_template` and `komodo_service_file_template` to define default templates for the configuration and service files, respectively.
* [`defaults/main.yml`](diffhunk://#diff-23e21b6c89468f7534697ad091835b3ee5e0213b37ace489488234e5a9548ec4R51-R52): Added a slight formatting change to improve readability.

### Task Updates:

* [`tasks/install.yml`](diffhunk://#diff-56337baca89bf90b2a43569fcfafae2fb14dc51dee973ac89275181f30f08c66L74-R82): Updated the `Deploy configuration file` and `Deploy systemd user service file` tasks to use the newly introduced `komodo_config_file_template` and `komodo_service_file_template` variables instead of hardcoding template file names.
* [`tasks/update.yml`](diffhunk://#diff-fcebdf2e76bf52998127568ef46b7f797965f35bfd23c2339761ac69ba2bce3fL56-R64): Applied the same updates as in `tasks/install.yml` to ensure consistency during updates.