### PR TITLE
Use `package` instead of `apt` for `systemd` systems.

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,7 +1,7 @@
 ---
 
 - name: Ensure ACL package exists when creating a new user
-  ansible.builtin.apt:
+  ansible.builtin.package:
     name: acl
     state: present
   become: true


### PR DESCRIPTION
(Candidate for the world's shortest PR)

Changes `install.yml` to use the more generally-applicable `ansible.builtin.package` module. Because `acl` is a `systemd` dependency, most systems that this role targets should be supported, such as the RedHat and Arch family of systems.

I tried this change on a set Debian, Alma Linux, and Rocky Linux of virtual machines and it caused no issues.

**Changes**
- `tasks/install.yml`
- Closes #20 

**Relevant Documentation**

[Ansible `package` module](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_module.html)

> This modules manages packages on a target without specifying a package manager module (like [ansible.builtin.dnf](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/dnf_module.html#ansible-collections-ansible-builtin-dnf-module), [ansible.builtin.apt](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/apt_module.html#ansible-collections-ansible-builtin-apt-module), …). It is convenient to use in an heterogeneous environment of machines without having to create a specific task for each package manager. [ansible.builtin.package](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_module.html#ansible-collections-ansible-builtin-package-module) calls behind the module for the package manager used by the operating system discovered by the module [ansible.builtin.setup](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/setup_module.html#ansible-collections-ansible-builtin-setup-module). If [ansible.builtin.setup](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/setup_module.html#ansible-collections-ansible-builtin-setup-module) was not yet run, [ansible.builtin.package](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/package_module.html#ansible-collections-ansible-builtin-package-module) will run it.