### PR TITLE
Implement automatic versioning

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -9,7 +9,7 @@
             "customType": "regex",
             "managerFilePatterns": [
                 "/defaults/main.yml$/",
-                "/README.md/"
+                "README\\.md$"
             ],
             "matchStrings": [
                 "komodo_version: [\"']?(?<currentValue>.+?)[\"']?\\s+",

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,28 @@
+---
+
+name: Run linter
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install ansible-lint
+        run: |
+          pip install ansible ansible-lint
+
+      - name: Run ansible-lint
+        run: |
+          ansible-lint -v .

--- a/README.md
+++ b/README.md
@@ -81,12 +81,20 @@ Some additional variables to tweak settings or override default behavior.
 ### Note on Generated Passkeys
 
 Enabling passkey generation for unique periphery passkeys with `generate_server_passkey=true` is potentially valuable, but if doing so remember to *always* enable
-this feature whenever you update or install that server. For example, if you generated a random passkey on install, and then *DIDN'T* generate a random passkey
-or set a passkey on a future update, it would overwrite the passkey. If you generated a passkey on install, and then disabled server management entirely on updates,
-then the role will have no knowledge of that generated passkey and it will not include that passkey in its allowed passkeys list, meaning you will lose connection.
+this feature whenever you update or install that server. 
+
+For example, if you generated a random passkey on install, and then *DIDN'T* generate a random passkey
+or set a passkey on a future update, it would not have a server passkey to provide to the server, and it will update it with no passkey. 
+
+Further, if you generated a passkey on install, and then disabled server management entirely on updates,
+then the role will have no knowledge of that generated passkey and it will not include that passkey in its allowed passkeys list, meaning you may be using
+no passkey at all. 
 
 Basically, the simple advice is to *ALWAYS* have `generate_server_passkey=true` or *ALWAYS* have `generate_server_passkey=false` for each server. I recommend setting
 these variables directly in an inventory file. See [`examples/server_management/inventory/all.yml`](./examples/server_management/inventory/all.yml) for an example.
+
+If this is not preferred, you can always generate on install, and then record the generated passkeys and include that explicitly in your `komodo_passkeys` from thereon.
+Or you can of course just always set your own randomly generated `server_passkey`
 
 ### Overriding default configuration templates
 

--- a/examples/auth/playbooks/komodo.yml
+++ b/examples/auth/playbooks/komodo.yml
@@ -5,7 +5,7 @@
     - role: bpbradley.komodo
       # Default action / version. Can be overriden on command line with -e
       komodo_action: "install"
-      komodo_version: "v1.18.3"
+      komodo_version: "latest"
       # These passkeys are used to authenticate with the komodo core instance
       # If the komodo core server/instance does not provide these passkeys,
       # then periphery will not be able to  communicate with it.

--- a/examples/basic/playbooks/komodo.yml
+++ b/examples/basic/playbooks/komodo.yml
@@ -5,7 +5,7 @@
     - role: bpbradley.komodo
       # Default action / version. Can be overriden on command line with -e
       komodo_action: "install"
-      komodo_version: "v1.18.3"
+      komodo_version: "latest"
       # We can specify some additional configurations to override defaults
       # refer to the `defaults/main.yml` for more details
       komodo_periphery_port: 8199

--- a/examples/server_management/playbooks/komodo.yml
+++ b/examples/server_management/playbooks/komodo.yml
@@ -4,5 +4,7 @@
   roles:
     - role: bpbradley.komodo
       # Default action / version. Can be overriden on command line with -e
+      # Since we gave API credentials for this role, we can check the
+      # version in Komodo Core and install the matching periphery version
       komodo_action: "install"
-      komodo_version: "v1.18.3"
+      komodo_version: "core"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -64,7 +64,7 @@
 
     - name: Download Komodo Periphery Agent
       ansible.builtin.get_url:
-        url: "https://github.com/moghtech/komodo/releases/download/{{ komodo_version }}/{{ binary_name }}"
+        url: "https://github.com/moghtech/komodo/releases/download/{{ _komodo_version }}/{{ binary_name }}"
         dest: "{{ komodo_bin_path }}"
         mode: "0755"
         owner: "{{ komodo_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,50 +9,86 @@
 - name: Set komodo_user_exists fact
   ansible.builtin.set_fact:
     komodo_user_exists: "{{ komodo_user_check.rc == 0 }}"
+  
+- name: Check for API credentials if using server management
+  when: enable_server_management and not (
+          komodo_core_url
+      and komodo_core_api_key
+      and komodo_core_api_secret
+    )
+  ansible.builtin.fail:
+    msg: >
+      Server management was enabled, but missing API credentials.
+      Make sure to provide a valid `komodo_core_url`, `komodo_core_api_key`,
+      and `komodo_core_api_secret`
 
+- name: Check for unsupported configuration
+  when: not enable_server_management and (
+          server_passkey
+    )
+  ansible.builtin.fail:
+    msg: >
+      Setting a server passkey when `enable_server_management=false`.
+      This is not a supported configuration, either enable server management,
+      or explicitly add your server_passkey to the `komodo_passkeys` list.
+      
 - name: Resolve komodo_version
   when: komodo_action in ["install","update"]
   block:
-    - name: Query Komodo Core for its current version
+    - name: Handle automatic versioning with core
       when: komodo_version | lower == "core"
-      ansible.builtin.uri:
-        url: "{{ komodo_core_url | trim('/') }}/read"
-        method: POST
-        body_format: json
-        headers:
-          Content-Type: application/json
-          X-Api-Key:    "{{ komodo_core_api_key }}"
-          X-Api-Secret: "{{ komodo_core_api_secret }}"
-        body:
-          type:   GetVersion
-          params: {}
-        status_code: 200
-        return_content: yes
-        timeout: 15
-      register: _core_version
+      block:
+        - name: Check for API credentials
+          when: not (
+                  komodo_core_url
+              and komodo_core_api_key
+              and komodo_core_api_secret
+            )
+          ansible.builtin.fail:
+            msg: >
+              Automatic versioning with "core" was requested, but missing API credentials.
+              Make sure to provide a valid `komodo_core_url`, `komodo_core_api_key`,
+              and `komodo_core_api_secret`
 
-    - name: Set komodo_version to Komodo Core response
-      when: komodo_version | lower == "core"
-      ansible.builtin.set_fact:
-        _komodo_version: "v{{ (_core_version.json.version | regex_replace('^v', '')) }}"
-      changed_when: false
+        - name: Query Core API to get Komodo version
+          ansible.builtin.uri:
+            url: "{{ komodo_core_url | trim('/') }}/read"
+            method: POST
+            body_format: json
+            headers:
+              Content-Type: application/json
+              X-Api-Key:    "{{ komodo_core_api_key }}"
+              X-Api-Secret: "{{ komodo_core_api_secret }}"
+            body:
+              type:   GetVersion
+              params: {}
+            status_code: 200
+            return_content: yes
+            timeout: 15
+          register: _core_version
+
+        - name: Set komodo_version to Komodo Core response
+          ansible.builtin.set_fact:
+            _komodo_version: "v{{ (_core_version.json.version | regex_replace('^v', '')) }}"
+          changed_when: false
       
-    - name: Query GitHub for the latest Komodo release
+    - name: Handle automatic versioning to latest
       when: komodo_version | lower == "latest"
-      ansible.builtin.uri:
-        url: "https://api.github.com/repos/moghtech/komodo/releases/latest"
-        headers:
-          Accept: application/vnd.github+json
-        return_content: yes
-        status_code: 200
-        timeout: 15
-      register: _gh_release
+      block:
+        - name: Query GitHub for the latest Komodo release
+          ansible.builtin.uri:
+            url: "https://api.github.com/repos/moghtech/komodo/releases/latest"
+            headers:
+              Accept: application/vnd.github+json
+            return_content: yes
+            status_code: 200
+            timeout: 15
+          register: _gh_release
 
-    - name: Set komodo_version to latest GitHub tag
-      when: komodo_version | lower == "latest"
-      ansible.builtin.set_fact:
-        _komodo_version: "{{ _gh_release.json.tag_name | regex_replace('^v', 'v') }}"
-      changed_when: false
+        - name: Set komodo_version to latest GitHub tag
+          ansible.builtin.set_fact:
+            _komodo_version: "{{ _gh_release.json.tag_name | regex_replace('^v', 'v') }}"
+          changed_when: false
 
     - name: Determine Komodo version
       when: _komodo_version is not defined
@@ -89,26 +125,25 @@
               + ([passkey] if passkey else [])
             ) | unique
           }}
+    - name: Generate a random passkey
+      when: enable_server_management and 
+            generate_server_passkey and 
+            not server_passkey 
+      ansible.builtin.set_fact:
+        server_passkey: >-
+          {{
+            lookup('password',
+            '/dev/null length=32 chars=ascii_letters,digits')
+          }}
     - name: Update allowed_passkeys with server_passkey
-      when: enable_server_management
-      block:
-        - name: Generate a random passkey
-          when: not server_passkey and generate_server_passkey
-          ansible.builtin.set_fact:
-            server_passkey: >-
-              {{
-                lookup('password',
-                '/dev/null length=32 chars=ascii_letters,digits')
-              }}
-        - name: Update allowed_passkeys
-          ansible.builtin.set_fact:
-            allowed_passkeys: >-
-              {{
-                (
-                  ([allowed_passkeys] | flatten)
-                  + ([server_passkey] if server_passkey else [])
-                ) | unique
-              }}
+      ansible.builtin.set_fact:
+        allowed_passkeys: >-
+          {{
+            (
+              ([allowed_passkeys] | flatten)
+              + ([server_passkey] if server_passkey else [])
+            ) | unique
+          }}
 
 - name: Include install tasks
   ansible.builtin.import_tasks: install.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,7 +9,7 @@
 - name: Set komodo_user_exists fact
   ansible.builtin.set_fact:
     komodo_user_exists: "{{ komodo_user_check.rc == 0 }}"
-  
+
 - name: Check for API credentials if using server management
   when: enable_server_management and not (
           komodo_core_url
@@ -31,7 +31,7 @@
       Setting a server passkey when `enable_server_management=false`.
       This is not a supported configuration, either enable server management,
       or explicitly add your server_passkey to the `komodo_passkeys` list.
-      
+
 - name: Resolve komodo_version
   when: komodo_action in ["install","update"]
   block:
@@ -57,13 +57,13 @@
             body_format: json
             headers:
               Content-Type: application/json
-              X-Api-Key:    "{{ komodo_core_api_key }}"
+              X-Api-Key: "{{ komodo_core_api_key }}"
               X-Api-Secret: "{{ komodo_core_api_secret }}"
             body:
-              type:   GetVersion
+              type: GetVersion
               params: {}
             status_code: 200
-            return_content: yes
+            return_content: true
             timeout: 15
           register: _core_version
 
@@ -71,7 +71,7 @@
           ansible.builtin.set_fact:
             _komodo_version: "v{{ (_core_version.json.version | regex_replace('^v', '')) }}"
           changed_when: false
-      
+
     - name: Handle automatic versioning to latest
       when: komodo_version | lower == "latest"
       block:
@@ -80,7 +80,7 @@
             url: "https://api.github.com/repos/moghtech/komodo/releases/latest"
             headers:
               Accept: application/vnd.github+json
-            return_content: yes
+            return_content: true
             status_code: 200
             timeout: 15
           register: _gh_release
@@ -94,7 +94,7 @@
       when: _komodo_version is not defined
       ansible.builtin.set_fact:
         _komodo_version: "{{ komodo_version }}"
-    
+
     - name: Display Komodo version
       ansible.builtin.debug:
         msg: "Using Komodo version: {{ _komodo_version }}"
@@ -126,9 +126,9 @@
             ) | unique
           }}
     - name: Generate a random passkey
-      when: enable_server_management and 
-            generate_server_passkey and 
-            not server_passkey 
+      when: enable_server_management and
+            generate_server_passkey and
+            not server_passkey
       ansible.builtin.set_fact:
         server_passkey: >-
           {{

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,20 +10,72 @@
   ansible.builtin.set_fact:
     komodo_user_exists: "{{ komodo_user_check.rc == 0 }}"
 
-# Choose binary_name based on user override, architecture, and version
+- name: Resolve komodo_version
+  when: komodo_action in ["install","update"]
+  block:
+    - name: Query Komodo Core for its current version
+      when: komodo_version | lower == "core"
+      ansible.builtin.uri:
+        url: "{{ komodo_core_url | trim('/') }}/read"
+        method: POST
+        body_format: json
+        headers:
+          Content-Type: application/json
+          X-Api-Key:    "{{ komodo_core_api_key }}"
+          X-Api-Secret: "{{ komodo_core_api_secret }}"
+        body:
+          type:   GetVersion
+          params: {}
+        status_code: 200
+        return_content: yes
+        timeout: 15
+      register: _core_version
+
+    - name: Set komodo_version to Komodo Core response
+      when: komodo_version | lower == "core"
+      ansible.builtin.set_fact:
+        _komodo_version: "v{{ (_core_version.json.version | regex_replace('^v', '')) }}"
+      changed_when: false
+      
+    - name: Query GitHub for the latest Komodo release
+      when: komodo_version | lower == "latest"
+      ansible.builtin.uri:
+        url: "https://api.github.com/repos/moghtech/komodo/releases/latest"
+        headers:
+          Accept: application/vnd.github+json
+        return_content: yes
+        status_code: 200
+        timeout: 15
+      register: _gh_release
+
+    - name: Set komodo_version to latest GitHub tag
+      when: komodo_version | lower == "latest"
+      ansible.builtin.set_fact:
+        _komodo_version: "{{ _gh_release.json.tag_name | regex_replace('^v', 'v') }}"
+      changed_when: false
+
+    - name: Determine Komodo version
+      when: _komodo_version is not defined
+      ansible.builtin.set_fact:
+        _komodo_version: "{{ komodo_version }}"
+    
+    - name: Display Komodo version
+      ansible.builtin.debug:
+        msg: "Using Komodo version: {{ _komodo_version }}"
+
 - name: Select Komodo binary
+  when: komodo_action in ["install","update"]
   ansible.builtin.set_fact:
     binary_name: >-
       {%- if komodo_bin | length > 0 -%}
         {{ komodo_bin }}
       {%- elif ansible_architecture == 'aarch64' -%}
         {{ komodo_bin_aarch64 }}
-      {%- else -%} {# x86_64 #}{%- if (komodo_version | regex_replace('^v', '')) is version('1.16.12', '>=') -%}
+      {%- else -%} {# x86_64 #}{%- if (_komodo_version | regex_replace('^v', '')) is version('1.16.12', '>=') -%}
           {{ komodo_bin_x86 }}
       {%- else -%}
           {{ komodo_bin_x86_legacy }}
       {%- endif -%} {%- endif -%}
-  when: komodo_action in ["install","update"]
 
 - name: Normalise Komodo passkeys
   when: komodo_action in ["install","update"]

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -46,7 +46,7 @@
 
     - name: Download Komodo Periphery Agent
       ansible.builtin.get_url:
-        url: "https://github.com/moghtech/komodo/releases/download/{{ komodo_version }}/{{ binary_name }}"
+        url: "https://github.com/moghtech/komodo/releases/download/{{ _komodo_version }}/{{ binary_name }}"
         dest: "{{ komodo_bin_path }}"
         mode: "0755"
         owner: "{{ komodo_user }}"

--- a/templates/periphery.config.toml.j2
+++ b/templates/periphery.config.toml.j2
@@ -9,7 +9,7 @@ stack_dir = "{{ stack_dir }}"
 stats_polling_rate = "{{ stacks_polling_rate }}"
 
 {#-- Only add bind_ip for Komodo >= v1.17.1 --#}
-{% if (komodo_version | regex_replace('^v', '')) is version('1.17.1', '>=') %}
+{% if (_komodo_version | regex_replace('^v', '')) is version('1.17.1', '>=') %}
 {{''}}
 bind_ip = "{{ komodo_bind_ip }}"
 {% endif %}


### PR DESCRIPTION
Allows `komodo_version` to be set to `latest` where it will get the latest github release, or `core`, where it will get the current version of komodo core, given API credentials were provided to query core.