### PR TITLE
Fix permissions

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -1,9 +1,9 @@
 ---
 - name: Run install procedure
   when: komodo_action == "install"
-  become: true
   block:
     - name: Ensure Komodo user exists
+      become: true
       ansible.builtin.user:
         name: "{{ komodo_user }}"
         shell: /usr/sbin/nologin
@@ -12,6 +12,7 @@
       when: komodo_user_exists is not defined or not komodo_user_exists
 
     - name: Create Ansible temp directory for komodo user
+      become: true
       ansible.builtin.file:
         path: "/home/{{ komodo_user }}/.ansible/tmp"
         state: directory
@@ -20,6 +21,7 @@
         mode: "0700"
 
     - name: Ensure necessary directories
+      become: true
       ansible.builtin.file:
         path: "{{ item }}"
         state: directory
@@ -32,6 +34,7 @@
         - "{{ komodo_service_dir }}"
 
     - name: Ensure SSL directory exists
+      become: true
       ansible.builtin.file:
         path: "/etc/komodo/ssl"
         state: directory
@@ -41,6 +44,7 @@
       when: ssl_enabled | default(true)
 
     - name: Add Komodo user to the docker group
+      become: true
       ansible.builtin.user:
         name: "{{ komodo_user }}"
         groups: docker
@@ -48,6 +52,7 @@
 
     - name: Enable lingering for Komodo user
       ansible.builtin.command: loginctl enable-linger {{ komodo_user }}
+      become: true
       changed_when: false
 
     - name: Stop periphery service
@@ -55,6 +60,7 @@
         export XDG_RUNTIME_DIR="/run/user/$(id -u {{ komodo_user }})"
         systemctl --user stop periphery || true
       become_user: "{{ komodo_user }}"
+      become: true
       changed_when: false
 
     - name: Fail if unsupported architecture
@@ -63,6 +69,7 @@
       when: ansible_architecture not in ['x86_64', 'aarch64']
 
     - name: Download Komodo Periphery Agent
+      become: true
       ansible.builtin.get_url:
         url: "https://github.com/moghtech/komodo/releases/download/{{ _komodo_version }}/{{ binary_name }}"
         dest: "{{ komodo_bin_path }}"
@@ -72,6 +79,7 @@
         force: true
 
     - name: Deploy configuration file
+      become: true
       ansible.builtin.template:
         src: "{{ komodo_config_file_template }}"
         dest: "{{ komodo_config_path }}"
@@ -80,6 +88,7 @@
         group: "{{ komodo_group }}"
 
     - name: Deploy systemd user service file
+      become: true
       ansible.builtin.template:
         src: "{{ komodo_service_file_template }}"
         dest: "{{ komodo_service_path }}"
@@ -92,9 +101,11 @@
         export XDG_RUNTIME_DIR="/run/user/$(id -u {{ komodo_user }})"
         systemctl --user daemon-reload
       become_user: "{{ komodo_user }}"
+      become: true
       changed_when: false
 
     - name: Enable and start periphery service
+      become: true
       ansible.builtin.shell: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u {{ komodo_user }})"
         systemctl --user enable --now periphery

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -1,21 +1,23 @@
 ---
 - name: Run uninstall procedure
   when: komodo_action == "uninstall"
-  become: true
   block:
     - name: Stop periphery service
       ansible.builtin.shell: |
         export XDG_RUNTIME_DIR="/run/user/$(id -u {{ komodo_user }})"
         systemctl --user stop periphery || true
       become_user: "{{ komodo_user }}"
+      become: true
       changed_when: false
 
     - name: Disable lingering for komodo user
       ansible.builtin.command: loginctl disable-linger {{ komodo_user }}
       changed_when: false
+      become: true
       when: komodo_delete_user | default(false)
 
     - name: Remove komodo directories
+      become: true
       ansible.builtin.file:
         path: "{{ item }}"
         state: absent
@@ -31,6 +33,7 @@
         systemctl --user disable periphery || true
         rm -f {{ komodo_service_path }}
       become_user: "{{ komodo_user }}"
+      become: true
       changed_when: false
 
     - name: Remove komodo user
@@ -39,6 +42,7 @@
         state: absent
         remove: true
         force: true
+      become: true
       when: komodo_delete_user | default(false)
 
     - name: Debug message after uninstall

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -16,7 +16,7 @@
         state: absent
       become: true
       when: komodo_bin_path is defined
-    
+
     - name: Ensure binary path exists for download
       ansible.builtin.file:
         path: "{{ komodo_bin_dir }}"


### PR DESCRIPTION
Running without `ansible_become=true` or not having the ansible.cfg set `become = True` by default, some tasks were failing. This should now work without forcing become=true on the entire role, and it will escalate as it needs to.