### PR TITLE
Add komodo secrets to periphery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Some additional variables to tweak settings or override default behavior.
 | **logging\_level**                        | `info`                                          | Periphery log level                                               |
 | **logging\_stdio**                        | `standard`                                      | Log output format                                                 |
 | **logging\_opentelemetry\_service\_name** | `Komodo-Periphery`                              | Service name reported to OpenTelemetry exporters                  |
+| **komodo_agent_secrets**                  | `[]`                                            | List of komodo secrets only available to the agent.               |
 
 ### Automatic Versioning
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -61,3 +61,5 @@ komodo_bin: ""
 komodo_bin_x86: "periphery-x86_64"
 komodo_bin_x86_legacy: "periphery"
 komodo_bin_aarch64: "periphery-aarch64"
+
+komodo_agent_secrets: []

--- a/templates/periphery.config.toml.j2
+++ b/templates/periphery.config.toml.j2
@@ -36,3 +36,16 @@ passkeys = {{ allowed_passkeys }}
 logging.level = "{{logging_level}}"
 logging.stdio = "{{logging_stdio}}"
 logging.opentelemetry_service_name = "{{logging_opentelemetry_service_name}}"
+
+###########
+# SECRETS #
+###########
+
+## Provide periphery-based secrets
+{% if len(komodo_agent_secrets) > 0 %}
+[secrets]
+{% for secret in komodo_agent_secrets %}
+
+{{ secret.name }} = "{{ secret.value }}"
+{% endfor %}
+{% endif %}

--- a/templates/periphery.config.toml.j2
+++ b/templates/periphery.config.toml.j2
@@ -42,7 +42,7 @@ logging.opentelemetry_service_name = "{{logging_opentelemetry_service_name}}"
 ###########
 
 ## Provide periphery-based secrets
-{% if len(komodo_agent_secrets) > 0 %}
+{% if komodo_agent_secrets | length > 0 %}
 [secrets]
 {% for secret in komodo_agent_secrets %}
 


### PR DESCRIPTION
Add the possibility to add secrets to the periphery config with var komodo_agent_secrets. 
Default is an empty list