### PR TITLE
Add ability to add extra env vars to systemd service file.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -21,6 +21,13 @@ komodo_allowed_ips: []
 #       value: "supersecret2"
 komodo_agent_secrets: []
 
+# Add name/value pairs containing extra env variables available to komodo periphery environment
+# Example:
+#   komodo_extra_env:
+#     - name: "EXTRA_ENV_NAME"
+#       value: "extra_env_value"
+komodo_extra_env: []
+
 # Necessary if we want to enable automatic management of the periphery server in core
 enable_server_management: false
 komodo_core_url: ""

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -87,6 +87,11 @@
         owner: "{{ komodo_user }}"
         group: "{{ komodo_group }}"
 
+    - name: Gather passwd entry for Komodo user (UID/GID)
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ komodo_user }}"
+
     - name: Deploy systemd user service file
       become: true
       ansible.builtin.template:

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -73,6 +73,11 @@
         owner: "{{ komodo_user }}"
         group: "{{ komodo_group }}"
 
+    - name: Gather passwd entry for Komodo user (UID/GID)
+      ansible.builtin.getent:
+        database: passwd
+        key: "{{ komodo_user }}"
+
     - name: Deploy systemd user service file
       become: true
       ansible.builtin.template:

--- a/templates/periphery.service.j2
+++ b/templates/periphery.service.j2
@@ -3,9 +3,17 @@ Description=Agent to connect with Komodo Core
 
 [Service]
 Environment="HOME={{ komodo_home }}"
+Environment="UID={{ ansible_facts.getent_passwd[komodo_user].1 }}"
+Environment="GID={{ ansible_facts.getent_passwd[komodo_user].2 }}"
+{% if komodo_extra_env | length > 0 %}
+{% for env in komodo_extra_env %}
+Environment="{{ env.name }}={{ env.value }}"
+{% endfor %}
+{% endif %}
 ExecStart=/bin/sh -lc "{{ komodo_bin_path }} --config-path {{ komodo_config_path }}"
 Restart=on-failure
 TimeoutStartSec=0
 
 [Install]
 WantedBy=default.target
+


### PR DESCRIPTION
Can now add extra env vars with `komodo_extra_env`

i.e.

```yaml
komodo_extra_env:
  - name: "EXTRA_ENV_NAME"
     value: "extra_env_value"
```
