### PR TITLE
Fix ownership of ssl directory

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -33,6 +33,15 @@
         - "{{ komodo_config_dir }}"
         - "{{ komodo_service_dir }}"
 
+    - name: Ensure Komodo base directory exists with correct ownership
+      become: true
+      ansible.builtin.file:
+        path: "/etc/komodo"
+        state: directory
+        owner: "{{ komodo_user }}"
+        group: "{{ komodo_group }}"
+        mode: "0750"
+
     - name: Ensure SSL directory exists
       become: true
       ansible.builtin.file:
@@ -41,6 +50,7 @@
         owner: "{{ komodo_user }}"
         group: "{{ komodo_group }}"
         mode: "0750"
+        recurse: true
       when: ssl_enabled | default(true)
 
     - name: Add Komodo user to the docker group

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -39,14 +39,24 @@
         - "{{ komodo_config_dir }}"
         - "{{ komodo_service_dir }}"
 
+    - name: Ensure Komodo base directory exists with correct ownership
+      become: true
+      ansible.builtin.file:
+        path: "/etc/komodo"
+        state: directory
+        owner: "{{ komodo_user }}"
+        group: "{{ komodo_group }}"
+        mode: "0750"
+
     - name: Ensure SSL directory exists
+      become: true
       ansible.builtin.file:
         path: "/etc/komodo/ssl"
         state: directory
         owner: "{{ komodo_user }}"
         group: "{{ komodo_group }}"
         mode: "0750"
-      become: true
+        recurse: true
       when: ssl_enabled | default(true)
 
     - name: Fail if unsupported architecture


### PR DESCRIPTION
Closes #27 

If the `/etc/komodo` or `/etc/komodo/ssl` or any of its contents already exist on system with the wrong permissions, the permissions would be wrong and periphery wont be able to generate certs. This change makes it so that the folder and all files are guaranteed to have the correct permissions.