### PR TITLE
Getent before deploy config

### DIFF
--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -87,7 +87,7 @@
         owner: "{{ komodo_user }}"
         group: "{{ komodo_group }}"
         force: true
-        
+
     - name: Gather passwd entry for Komodo user (UID/GID)
       ansible.builtin.getent:
         database: passwd

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -73,7 +73,7 @@
         owner: "{{ komodo_user }}"
         group: "{{ komodo_group }}"
         force: true
-        
+
     - name: Gather passwd entry for Komodo user (UID/GID)
       ansible.builtin.getent:
         database: passwd


### PR DESCRIPTION
There are use cases that user information might be useful in deploy config stage.

For example, you can now add komodo UID/GID to komodo secrets on periphery, so they can easily be interpolated.

Example inventory snippet
```yaml
  komodo_agent_secrets:
  - name: "KOMODO_UID"
    value: "{{ ansible_facts.getent_passwd[komodo_user].1 }}"
  - name: "KOMODO_GID"
    value: "{{ ansible_facts.getent_passwd[komodo_user].2 }}"
````