### PR TITLE
System wide service

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ the numerous edge cases which appear when running it as a docker container.
 3. **Uninstall** the Komodo Periphery agent, optionally removing the `komodo` user and home directories.
 4. **Manage Servers** in Komodo Core directly, so that you don't have to manually add/update them in core after deployment.
 
+## Service Deployment Options
+
+This role supports two systemd service deployment modes:
+
+### User Service (Default)
+- Service runs as a user service under the `komodo` user
+- Service files are placed in `~/.config/systemd/user/`
+- Requires user session to be active for the service to run
+- Uses `systemctl --user` commands for management
+- Default behavior when `komodo_systemwide_service: false`
+
+### System-wide Service
+- Service runs as a system-wide service but still executes as the `komodo` user
+- Service files are placed in `/etc/systemd/system/`
+- Service starts automatically at boot without requiring user login
+- Uses standard `systemctl` commands for management
+- Enabled by setting `komodo_systemwide_service: true`
+
+Both modes maintain the same security posture by running the service as the restricted `komodo` user.
+
 ## Required Role Variables
 
 For all role variables, see [`defaults/main.yml`](./defaults/main.yml) for more details. Below are the only required variables if you are otherwise okay with defaults.
@@ -78,13 +98,14 @@ Some additional variables to tweak settings or override default behavior.
 | ----------------------------------------- | ----------------------------------------------- | ----------------------------------------------------------------- |
 | **komodo\_user**                          | `komodo`                                        | System user that owns files and runs the service                  |
 | **komodo\_group**                         | `komodo`                                        | Group that owns files and runs the service                        |
+| **komodo\_systemwide\_service**           | `false`                                         | Run as system-wide service instead of user service (still runs as komodo user) |
 | **komodo\_home**                          | `/home/{{ komodo_user }}`                       | Home directory of `komodo_user`                                   |
 | **komodo\_extra\_env**                    | `[]`                                            | List (name/value pairs) of extra env vars available to periphery  |
 | **komodo\_delete\_user**                  | `None`                                          | Only when `komodo_action=uninstall`, *deletes* `komodo_user`      |
 | **komodo\_config\_dir**                   | `{{ komodo_home }}/.config/komodo`              | Directory that holds Komodo configuration files                   |
 | **komodo\_config\_file\_template**        | `periphery.config.toml.j2`                      | ([Refer to Note](#overriding-default-configuration-templates))    |
 | **komodo\_config\_path**                  | `{{ komodo_config_dir }}/periphery.config.toml` | Destination path of the rendered config file                      |
-| **komodo\_service\_dir**                  | `{{ komodo_home }}/.config/systemd/user`        | Directory for systemd user-mode unit files                        |
+| **komodo\_service\_dir**                  | `{{ komodo_home }}/.config/systemd/user` (user) or `/etc/systemd/system` (system) | Directory for systemd unit files (conditional based on service type) |
 | **komodo\_service\_file\_template**       | `periphery.service.j2`                          | ([Refer to Note](#overriding-default-configuration-templates))    |
 | **komodo\_service\_path**                 | `{{ komodo_service_dir }}/periphery.service`    | Destination path of the rendered service file                     |
 | **periphery\_port**                       | `8120`                                          | TCP port the server listens on                                    |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -41,6 +41,11 @@ generate_server_passkey: false # Allow a generation of a random passkey
 komodo_user: "komodo"
 komodo_group: "{{ komodo_user }}"
 
+# Toggle to run as system-wide service instead of user service
+# When true: service runs system-wide with User= directive (still as komodo user)
+# When false: service runs as user service (default behavior)
+komodo_systemwide_service: false
+
 komodo_home: "/home/{{ komodo_user }}"
 komodo_bin_dir: "{{ komodo_home }}/.local/bin"
 komodo_bin_path: "{{ komodo_bin_dir }}/periphery"
@@ -50,7 +55,7 @@ komodo_config_dir: "{{ komodo_home }}/.config/komodo"
 komodo_config_file_template: "periphery.config.toml.j2"
 komodo_config_path: "{{ komodo_config_dir }}/periphery.config.toml"
 
-komodo_service_dir: "{{ komodo_home }}/.config/systemd/user"
+komodo_service_dir: "{{ '/etc/systemd/system' if komodo_systemwide_service else komodo_home + '/.config/systemd/user' }}"
 # default service template
 komodo_service_file_template: "periphery.service.j2"
 komodo_service_path: "{{ komodo_service_dir }}/periphery.service"

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -63,8 +63,31 @@
       loop:
         - "{{ komodo_bin_dir }}"
         - "{{ komodo_config_dir }}"
-        - "{{ komodo_service_dir }}"
       when: not ansible_check_mode
+
+    - name: Ensure user service directory exists
+      become: true
+      ansible.builtin.file:
+        path: "{{ komodo_service_dir }}"
+        state: directory
+        owner: "{{ komodo_user }}"
+        group: "{{ komodo_group }}"
+        mode: "0750"
+      when:
+        - not ansible_check_mode
+        - not komodo_systemwide_service
+
+    - name: Ensure system service directory exists
+      become: true
+      ansible.builtin.file:
+        path: "{{ komodo_service_dir }}"
+        state: directory
+        owner: root
+        group: root
+        mode: "0755"
+      when:
+        - not ansible_check_mode
+        - komodo_systemwide_service
 
     - name: Ensure Komodo base directory exists
       become: true
@@ -161,6 +184,20 @@
       when:
         - komodo_user_exists
         - not ansible_check_mode
+        - not komodo_systemwide_service
+
+    - name: Deploy systemd system service file
+      become: true
+      ansible.builtin.template:
+        src: "{{ komodo_service_file_template }}"
+        dest: "{{ komodo_service_path }}"
+        mode: "0644"
+        owner: root
+        group: root
+      when:
+        - komodo_user_exists
+        - not ansible_check_mode
+        - komodo_systemwide_service
 
     - name: Reload user systemd
       become: true
@@ -173,8 +210,18 @@
       when:
         - komodo_user_exists
         - not ansible_check_mode
+        - not komodo_systemwide_service
 
-    - name: Enable periphery
+    - name: Reload system systemd
+      become: true
+      ansible.builtin.systemd:
+        daemon_reload: true
+      when:
+        - komodo_user_exists
+        - not ansible_check_mode
+        - komodo_systemwide_service
+
+    - name: Enable periphery (user service)
       become: true
       become_user: "{{ komodo_user }}"
       ansible.builtin.systemd:
@@ -186,8 +233,19 @@
       when:
         - komodo_user_exists
         - not ansible_check_mode
+        - not komodo_systemwide_service
 
-    - name: Start periphery
+    - name: Enable periphery (system service)
+      become: true
+      ansible.builtin.systemd:
+        name: periphery
+        enabled: true
+      when:
+        - komodo_user_exists
+        - not ansible_check_mode
+        - komodo_systemwide_service
+
+    - name: Start periphery (user service)
       become: true
       become_user: "{{ komodo_user }}"
       ansible.builtin.systemd:
@@ -199,3 +257,14 @@
       when:
         - komodo_user_exists
         - not ansible_check_mode
+        - not komodo_systemwide_service
+
+    - name: Start periphery (system service)
+      become: true
+      ansible.builtin.systemd:
+        name: periphery
+        state: started
+      when:
+        - komodo_user_exists
+        - not ansible_check_mode
+        - komodo_systemwide_service

--- a/tasks/uninstall.yml
+++ b/tasks/uninstall.yml
@@ -2,7 +2,7 @@
 - name: Run uninstall procedure
   when: komodo_action == "uninstall"
   block:
-    - name: Stop periphery service
+    - name: Stop periphery service (user)
       become: true
       become_user: "{{ komodo_user }}"
       environment:
@@ -12,9 +12,21 @@
         state: stopped
         scope: user
       failed_when: false
-      when: komodo_user_exists
+      when:
+        - komodo_user_exists
+        - not komodo_systemwide_service
 
-    - name: Disable periphery
+    - name: Stop periphery service (system)
+      become: true
+      ansible.builtin.systemd:
+        name: periphery
+        state: stopped
+      failed_when: false
+      when:
+        - komodo_user_exists
+        - komodo_systemwide_service
+
+    - name: Disable periphery (user)
       become: true
       become_user: "{{ komodo_user }}"
       ansible.builtin.systemd:
@@ -25,7 +37,20 @@
         XDG_RUNTIME_DIR: "/run/user/{{ getent_passwd[komodo_user].1 }}"
       failed_when: false
       changed_when: false
-      when: komodo_user_exists
+      when:
+        - komodo_user_exists
+        - not komodo_systemwide_service
+
+    - name: Disable periphery (system)
+      become: true
+      ansible.builtin.systemd:
+        name: periphery
+        enabled: false
+      failed_when: false
+      changed_when: false
+      when:
+        - komodo_user_exists
+        - komodo_systemwide_service
 
     - name: Remove periphery unit file
       become: true
@@ -33,7 +58,7 @@
         path: "{{ komodo_service_path }}"
         state: absent
 
-    - name: Reload systemd daemon
+    - name: Reload systemd daemon (user)
       become: true
       become_user: "{{ komodo_user }}"
       ansible.builtin.systemd:
@@ -41,7 +66,17 @@
         scope: user
       environment:
         XDG_RUNTIME_DIR: "/run/user/{{ getent_passwd[komodo_user].1 }}"
-      when: komodo_user_exists
+      when:
+        - komodo_user_exists
+        - not komodo_systemwide_service
+
+    - name: Reload systemd daemon (system)
+      become: true
+      ansible.builtin.systemd:
+        daemon_reload: true
+      when:
+        - komodo_user_exists
+        - komodo_systemwide_service
 
     - name: Disable lingering for komodo user
       ansible.builtin.command: loginctl disable-linger {{ komodo_user }}

--- a/tasks/update.yml
+++ b/tasks/update.yml
@@ -100,6 +100,17 @@
         mode: "0644"
         owner: "{{ komodo_user }}"
         group: "{{ komodo_group }}"
+      when: not komodo_systemwide_service
+
+    - name: Deploy systemd system service file
+      become: true
+      ansible.builtin.template:
+        src: "{{ komodo_service_file_template }}"
+        dest: "{{ komodo_service_path }}"
+        mode: "0644"
+        owner: root
+        group: root
+      when: komodo_systemwide_service
 
     - name: Reload user systemd
       become: true
@@ -109,9 +120,19 @@
         scope: user
       environment:
         XDG_RUNTIME_DIR: "/run/user/{{ getent_passwd[komodo_user].1 }}"
-      when: komodo_user_exists
+      when:
+        - komodo_user_exists
+        - not komodo_systemwide_service
 
-    - name: Enable periphery
+    - name: Reload system systemd
+      become: true
+      ansible.builtin.systemd:
+        daemon_reload: true
+      when:
+        - komodo_user_exists
+        - komodo_systemwide_service
+
+    - name: Enable periphery (user service)
       become: true
       become_user: "{{ komodo_user }}"
       ansible.builtin.systemd:
@@ -120,9 +141,20 @@
         scope: user
       environment:
         XDG_RUNTIME_DIR: "/run/user/{{ getent_passwd[komodo_user].1 }}"
-      when: komodo_user_exists
+      when:
+        - komodo_user_exists
+        - not komodo_systemwide_service
 
-    - name: Start periphery
+    - name: Enable periphery (system service)
+      become: true
+      ansible.builtin.systemd:
+        name: periphery
+        enabled: true
+      when:
+        - komodo_user_exists
+        - komodo_systemwide_service
+
+    - name: Start periphery (user service)
       become: true
       become_user: "{{ komodo_user }}"
       ansible.builtin.systemd:
@@ -131,4 +163,15 @@
         scope: user
       environment:
         XDG_RUNTIME_DIR: "/run/user/{{ getent_passwd[komodo_user].1 }}"
-      when: komodo_user_exists
+      when:
+        - komodo_user_exists
+        - not komodo_systemwide_service
+
+    - name: Start periphery (system service)
+      become: true
+      ansible.builtin.systemd:
+        name: periphery
+        state: started
+      when:
+        - komodo_user_exists
+        - komodo_systemwide_service

--- a/templates/periphery.service.j2
+++ b/templates/periphery.service.j2
@@ -4,6 +4,10 @@ StartLimitIntervalSec=15min
 StartLimitBurst=180
 
 [Service]
+{% if komodo_systemwide_service %}
+User={{ komodo_user }}
+Group={{ komodo_group }}
+{% endif %}
 Environment="HOME={{ komodo_home }}"
 Environment="UID={{ ansible_facts.getent_passwd[komodo_user].1 }}"
 Environment="GID={{ ansible_facts.getent_passwd[komodo_user].2 }}"
@@ -18,5 +22,5 @@ RestartSec=5s
 TimeoutStartSec=0
 
 [Install]
-WantedBy=default.target
+WantedBy={{ 'multi-user.target' if komodo_systemwide_service else 'default.target' }}
 


### PR DESCRIPTION
Hey @bpbradley , First thanks for creating this awesome role, I noticed while using it on a machine of mine that the following happens :

- the user is created (komodo user)
- lingering is enabled
- config files are in place (/home/komodo/.config/systemd/user/periphery.service)

but for some reason the service keeps on not starting and when I try to debug on the server I try the following :
- First I try switching to the user to start the service from there since it is user scoped 😄 but silly me that user is meant to be no login so I try this to override that 
```
sudo chsh -s /bin/bash komodo
su - komodo
systemctl --user daemon-reload
Failed to connect to bus: No such file or directory
```
and also tried this afterwards (the same pattern as in the role ?)
```
sudo -u komodo XDG_RUNTIME_DIR=/run/user/$(id -u komodo) systemd --user Failed to create /user.slice/user-1000.slice/session-536801.scope/init.scope control group: Permission denied Failed to allocate manager object: Permission denied
```

I don't know if is it a env issue on my end or something but hey it is what I faced and this PR fixed it for me (idk if it is secure tho since it is a system service ?)
Server OS :
```
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04.6 LTS"
```
maybe cause my OS is a bit old at this point ?

please review as you see fit and it would be awesome to merge so I can use the published role again 😊

Thanks !