### PR TITLE
Add delegate_to: localhost

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -86,6 +86,7 @@
             status_code: 200
             return_content: true
             timeout: 15
+          delegate_to: localhost
           register: _core_version
 
         - name: Set komodo_version to Komodo Core response

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -55,7 +55,7 @@
 
 - name: Check for unsupported configuration
   when: (not (enable_server_management | bool)) and (
-          (server_passkey is defined) and ((server_passkey | string | trim) | length > 0)
+    (server_passkey is defined) and ((server_passkey | string | trim) | length > 0)
     )
   ansible.builtin.fail:
     msg: >
@@ -72,6 +72,8 @@
         - name: Query Core API to get Komodo version
           check_mode: false
           changed_when: false
+          delegate_to: localhost
+          run_once: true
           ansible.builtin.uri:
             url: "{{ komodo_core_url | trim('/') }}/read"
             method: POST
@@ -86,7 +88,6 @@
             status_code: 200
             return_content: true
             timeout: 15
-          delegate_to: localhost
           register: _core_version
 
         - name: Set komodo_version to Komodo Core response
@@ -100,6 +101,8 @@
         - name: Query GitHub for the latest Komodo release
           check_mode: false
           changed_when: false
+          delegate_to: localhost
+          run_once: true
           ansible.builtin.uri:
             url: "https://api.github.com/repos/moghtech/komodo/releases/latest"
             headers:

--- a/tasks/manage_server.yml
+++ b/tasks/manage_server.yml
@@ -1,5 +1,4 @@
 ---
-
 - name: Create Server with Komodo Core
   when: enable_server_management | bool
   block:
@@ -34,8 +33,8 @@
         - name: Pick first IPv4
           ansible.builtin.set_fact:
             _core_dest_ip: "{{ host_lookup.stdout_lines
-                        | select('match', '^[0-9]+\\.')
-                        | map('split') | map('first') | first | default('') }}"
+              | select('match', '^[0-9]+\\.')
+              | map('split') | map('first') | first | default('') }}"
 
         - name: Fallback to default interface if something went wrong
           ansible.builtin.set_fact:
@@ -75,6 +74,7 @@
     - name: Check for existing server on Komodo Core
       check_mode: false
       changed_when: false
+      delegate_to: localhost
       ansible.builtin.uri:
         url: "{{ komodo_core_url | trim('/') }}/read"
         method: POST
@@ -94,6 +94,7 @@
 
     - name: Update server in Komodo Core
       when: not ansible_check_mode and probe.status == 200
+      delegate_to: localhost
       ansible.builtin.uri:
         url: "{{ komodo_core_url | trim('/') }}/write"
         method: POST
@@ -116,6 +117,7 @@
 
     - name: Create server with Komodo Core
       when: not ansible_check_mode and probe.status == 500
+      delegate_to: localhost
       ansible.builtin.uri:
         url: "{{ komodo_core_url | trim('/') }}/write"
         method: POST


### PR DESCRIPTION
I added 'delegate_to: localhost' to the 'Query Core API to get Komodo version' task because I don't want all my servers to have access to my Komodo web interface.