### PR TITLE
Add root_dir

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,8 +56,7 @@ komodo_service_file_template: "periphery.service.j2"
 komodo_service_path: "{{ komodo_service_dir }}/periphery.service"
 
 periphery_port: 8120
-repo_dir: "{{ komodo_home }}/.komodo/repos"
-stack_dir: "{{ komodo_home }}/.komodo/stacks"
+root_dir: "{{ komodo_home }}/.komodo"
 stacks_polling_rate: "5-sec"
 
 ssl_enabled: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -57,6 +57,8 @@ komodo_service_path: "{{ komodo_service_dir }}/periphery.service"
 
 periphery_port: 8120
 root_dir: "{{ komodo_home }}/.komodo"
+repo_dir: "{{ komodo_home }}/.komodo/repos"
+stack_dir: "{{ komodo_home }}/.komodo/stacks"
 stacks_polling_rate: "5-sec"
 
 ssl_enabled: true

--- a/templates/periphery.config.toml.j2
+++ b/templates/periphery.config.toml.j2
@@ -5,6 +5,8 @@
 # General server settings
 port = {{periphery_port}}
 root_directory = "{{ root_dir }}"
+repo_dir = "{{ repo_dir }}"
+stack_dir = "{{ stack_dir }}"
 stats_polling_rate = "{{ stacks_polling_rate }}"
 
 {#-- Only add bind_ip for Komodo >= v1.17.1 --#}

--- a/templates/periphery.config.toml.j2
+++ b/templates/periphery.config.toml.j2
@@ -4,8 +4,7 @@
 
 # General server settings
 port = {{periphery_port}}
-repo_dir = "{{ repo_dir }}"
-stack_dir = "{{ stack_dir }}"
+root_directory = "{{ root_dir }}"
 stats_polling_rate = "{{ stacks_polling_rate }}"
 
 {#-- Only add bind_ip for Komodo >= v1.17.1 --#}


### PR DESCRIPTION
I added root_dir as this was updated in Komodo v1.17.2 (https://github.com/moghtech/komodo/releases/tag/v1.17.2).
I also included conditional logic so that existing configurations are not broken if stack_dir or repo_dir is already set.