### PR TITLE
Fix allowed_ips with array and quotes

### DIFF
--- a/templates/periphery.config.toml.j2
+++ b/templates/periphery.config.toml.j2
@@ -28,9 +28,9 @@ legacy_compose_cli = false
 # Security #
 ###########
 
-ssl_enabled = {{ssl_enabled | lower}}
+ssl_enabled = {{ ssl_enabled | lower }}
 
-allowed_ips = {{komodo_allowed_ips}}
+allowed_ips = ["{{ komodo_allowed_ips }}"]
 
 {% if allowed_passkeys %}
 passkeys = {{ allowed_passkeys }}
@@ -40,9 +40,9 @@ passkeys = {{ allowed_passkeys }}
 # Logging #
 ###########
 
-logging.level = "{{logging_level}}"
-logging.stdio = "{{logging_stdio}}"
-logging.opentelemetry_service_name = "{{logging_opentelemetry_service_name}}"
+logging.level = "{{ logging_level }}"
+logging.stdio = "{{ logging_stdio }}"
+logging.opentelemetry_service_name = "{{ logging_opentelemetry_service_name }}"
 
 ###########
 # SECRETS #


### PR DESCRIPTION
I encountered this error while deploying additional peripheral agents:

```
Sep 24 18:42:10 <HOST> sh[12345]: Error: task 3 panicked with message:
    "failed at parsing config from paths: ParseFinalJson { 
        e: Error(\"invalid type: string \\\"::ffff:192.0.2.10\\\", expected Vec<T>\", line: 0, column: 0) 
    }"

Sep 24 18:42:10 <HOST> systemd[11111]: periphery.service: Main process exited, code=exited, status=1/FAILURE
Sep 24 18:42:10 <HOST> systemd[11111]: periphery.service: Failed with result 'exit-code'.
Sep 24 18:42:12 <HOST> systemd[11111]: Stopped periphery.service - Agent to connect with Komodo Core.
Sep 24 18:42:29 <HOST> systemd[11111]: Started periphery.service - Agent to connect with Komodo Core.

Sep 24 18:42:29 <HOST> sh[12346]: WARN: Failed to parse toml file at /home/komodo/.config/komodo/periphery.config.toml
    Error { 
        message: "string values must be quoted, expected literal string", 
        input: Some("
################################
# 🦎 PERIPHERY CONFIG 🦎 #
################################

# General server settings
port = 8120
root_dir = \"/home/komodo/.komodo\"

repo_dir = \"/home/komodo/.komodo/repos\"
stack_dir = \"/home/komodo/.komodo/stacks\"
build_dir = \"/home/komodo/.komodo/build\"
stats_polling_rate = \"5-sec\"
bind_ip = \"192.0.2.20\"

# Docker CLI options
legacy_compose_cli = false

###########
# Security #
###########

ssl_enabled = true

allowed_ips = ::ffff:192.0.2.10

passkeys = ['<REDACTED_SECRET_KEY>']

###########
# Logging #
###########

logging.level = \"info\"
logging.stdio = \"standard\"
logging.opentelemetry_service_name = \"Komodo-Periphery\"

###########
# SECRETS #
###########

## Provide periphery-based secrets
"), 
        keys: [], 
        span: Some(470..491) 
    }

Sep 24 18:42:29 <HOST> sh[12346]: 2025-09-24T16:42:29.175277Z  INFO periphery: Komodo Periphery version: v1.19.4

Sep 24 18:42:29 <HOST> sh[12346]: 2025-09-24T16:42:29.175539Z  INFO periphery: PeripheryConfig { 
    port: 8120, 
    bind_ip: "[::]", 
    root_directory: "/etc/komodo", 
    repo_dir: None, 
    stack_dir: None, 
    build_dir: None, 
    disable_terminals: false, 
    disable_container_exec: false, 
    stats_polling_rate: FiveSeconds, 
    container_stats_polling_rate: ThirtySeconds, 
    legacy_compose_cli: false, 
    logging: LogConfig { 
        level: Info, 
        stdio: Standard, 
        pretty: false, 
        location: true, 
        otlp_endpoint: "", 
        opentelemetry_service_name: "Komodo" 
    }, 
    pretty_startup_config: false, 
    allowed_ips: ForgivingVec([]), 
    passkeys: [], 
    include_disk_mounts: ForgivingVec([]), 
    exclude_disk_mounts: ForgivingVec([]), 
    secrets: {}, 
    git_providers: ForgivingVec([]), 
    docker_registries: ForgivingVec([]), 
    ssl_enabled: true, 
    ssl_key_file: None, 
    ssl_cert_file: None 
}

Sep 24 18:42:29 <HOST> sh[12346]: 2025-09-24T16:42:29.176464Z  INFO periphery: 🔒 Periphery SSL Enabled
Sep 24 18:42:29 <HOST> sh[12346]: 2025-09-24T16:42:29.176696Z  INFO periphery: Komodo Periphery starting on https://[::]:8120

```

For this reason, I added the array brackets and the quotes.
The array brackets are like in the [example config](https://github.com/moghtech/komodo/blob/494d01aeed6b645822909c0ca8a902437ffbbf66/config/periphery.config.toml#L110).
I tried to add the same array brackets to the passkeys for consistency, but then I saw that Ansible had already done this in the `Normalise Komodo passkeys` task.